### PR TITLE
fix requirements.txt to last supported version of lxml

### DIFF
--- a/Apps/Python-flask-xxe/vulnserver/src/requirements.txt
+++ b/Apps/Python-flask-xxe/vulnserver/src/requirements.txt
@@ -1,3 +1,3 @@
 flask
-lxml
+lxml==4.9.4
 pycrypto


### PR DESCRIPTION
Without this pip will try to install lxml 5, but it is unsupported by current code base, so the easiest solution is to add this restriction